### PR TITLE
ci: replaced DEVOLUTIONBOT_TOKEN secret

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -3,25 +3,25 @@ on:
   workflow_dispatch:
     inputs:
       run_id:
-        description: 'workflow run id'
-        default: "latest"
+        description: workflow run id
+        default: latest
         required: true
       rev_id:
-        description: 'build revision id'
-        default: "0"
+        description: build revision id
+        default: '0'
         required: true
-      dry-run:
-        description: 'Build packages without publishing'
+      dry_run:
+        description: Build packages without publishing
         required: true
         type: boolean
-        default: 'true'
+        default: true
 
 jobs:
   package:
     name: Build packages
     runs-on: windows-2022
     environment: publish-prod
-    
+
     steps:
       - name: Clone project
         uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          $RunId = '${{ github.event.inputs.run_id }}'
+          $RunId = '${{ inputs.run_id }}'
           if ($RunId -eq 'latest') {
             $RunId = $(gh run list -w 'Windows Terminal' --json 'status,databaseId,conclusion') |
               ConvertFrom-Json | Where-Object { ($_.status -eq 'completed') -and ($_.conclusion -eq 'success') } |
@@ -54,7 +54,7 @@ jobs:
               Remove-Item $_.Directory -ErrorAction SilentlyContinue
             }
           }
-          $RevId = '${{ github.event.inputs.rev_id }}'
+          $RevId = '${{ inputs.rev_id }}'
           $Version -Replace "(\d+).(\d+).(\d+).(\d+)", "`$1.`$2.`$3.$RevId"
           New-Item .\package -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
           Set-Content -Path .\VERSION -Value $Version -NoNewLine -Force
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-20.04
     environment: publish
     needs: package
-    if: ${{ github.event.inputs.dry-run == 'false' }} 
+    if: ${{ inputs.dry_run == false }}
 
     steps:
       - name: Download packages
@@ -177,7 +177,7 @@ jobs:
       - name: Create GitHub Release
         shell: pwsh
         env:
-          GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: package
         run: |
           $Version = Get-Content -Path .\VERSION

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -3,12 +3,12 @@ on:
   workflow_dispatch:
     inputs:
       run_id:
-        description: 'workflow run id'
-        default: "latest"
+        description: workflow run id
+        default: latest
         required: true
       rev_id:
-        description: 'build revision id'
-        default: "0"
+        description: build revision id
+        default: '0'
         required: true
 
 jobs:
@@ -16,7 +16,7 @@ jobs:
     name: Build packages
     runs-on: windows-2022
     environment: publish-test
-    
+
     steps:
       - name: Clone project
         uses: actions/checkout@v3
@@ -30,7 +30,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          $RunId = '${{ github.event.inputs.run_id }}'
+          $RunId = '${{ inputs.run_id }}'
           if ($RunId -eq 'latest') {
             $RunId = $(gh run list -w 'Windows Terminal' --json 'status,databaseId,conclusion') |
               ConvertFrom-Json | Where-Object { ($_.status -eq 'completed') -and ($_.conclusion -eq 'success') } |
@@ -49,7 +49,7 @@ jobs:
               Remove-Item $_.Directory -ErrorAction SilentlyContinue
             }
           }
-          $RevId = '${{ github.event.inputs.rev_id }}'
+          $RevId = '${{ inputs.rev_id }}'
           $Version -Replace "(\d+).(\d+).(\d+).(\d+)", "`$1.`$2.`$3.$RevId"
           New-Item .\package -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
           Set-Content -Path .\VERSION -Value $Version -NoNewLine -Force

--- a/.github/workflows/windows-terminal.yml
+++ b/.github/workflows/windows-terminal.yml
@@ -3,18 +3,18 @@ on:
   workflow_dispatch:
     inputs:
       git_ref:
-        description: 'upstream git ref'
-        default: "v1.16.10231.0"
+        description: upstream git ref
+        default: 'v1.16.10231.0'
         required: true
       version:
-        description: 'build version'
-        default: "1.16.10231.0"
+        description: build version
+        default: '1.16.10231.0'
         required: true
 
 jobs:
   build:
-    name: Windows Terminal [${{matrix.arch}}]
-    runs-on: ${{matrix.runner}}
+    name: Windows Terminal [${{ matrix.arch }}]
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: true
       matrix:
@@ -23,30 +23,30 @@ jobs:
         include:
           - os: windows
             runner: windows-2022
-  
+
     steps:
       - name: Clone project
         uses: actions/checkout@v3
 
-      - name: Clone Windows Terminal ${{github.event.inputs.git_ref}}
+      - name: Clone Windows Terminal ${{ inputs.git_ref }}
         uses: actions/checkout@v3
         with:
           repository: microsoft/terminal
-          ref: ${{github.event.inputs.git_ref}}
+          ref: ${{ inputs.git_ref }}
           submodules: true
           path: WindowsTerminal
 
       - name: Patch Windows Terminal
         shell: pwsh
         working-directory: WindowsTerminal
-        run: |          
+        run: |
           git apply ../patches/add-wt-base-settings-path-env-var.patch --ignore-whitespace
           git apply ../patches/add-wt-parent-window-handle-env-var.patch --ignore-whitespace
           git apply ../patches/fix-wt-release-manifest-proxy-stub-clsids.patch --ignore-whitespace
           git apply ../patches/add-wt-version-rc-files-to-projects.patch --ignore-whitespace
           git apply ../patches/enable-wt-hybrid-crt-use-static-msvc-runtime.patch --ignore-whitespace
 
-          ..\scripts\SetVersionInfo.ps1 (Get-Location).Path "${{github.event.inputs.version}}"
+          ..\scripts\SetVersionInfo.ps1 (Get-Location).Path "${{ inputs.version }}"
 
           Copy-Item ..\resources\images-rdm .\res\terminal -Recurse -Force
           Copy-Item ..\resources\terminal.ico .\res\terminal.ico -Force
@@ -74,7 +74,7 @@ jobs:
         shell: pwsh
         working-directory: C:\workspace\WindowsTerminal
         run: |
-          $TargetPlatform="${{matrix.arch}}"
+          $TargetPlatform="${{ matrix.arch }}"
           Import-Module .\tools\OpenConsole.psm1
           Set-MsBuildDevEnvironment
           $MSBuildOptions = @(
@@ -89,8 +89,8 @@ jobs:
         shell: pwsh
         working-directory: C:\workspace\WindowsTerminal
         run: |
-          $TargetPlatform="${{matrix.arch}}"
-          $PackageVersion = "${{github.event.inputs.version}}"
+          $TargetPlatform="${{ matrix.arch }}"
+          $PackageVersion = "${{ inputs.version }}"
           $PackageName = "WindowsTerminal-${PackageVersion}-${TargetPlatform}"
           Import-Module .\tools\OpenConsole.psm1
           Set-MsBuildDevEnvironment
@@ -105,5 +105,5 @@ jobs:
       - name: Upload Windows Terminal package
         uses: actions/upload-artifact@v3
         with:
-          name: WindowsTerminal-${{github.event.inputs.version}}-${{matrix.arch}}
-          path: C:\workspace\WindowsTerminal-${{github.event.inputs.version}}-${{matrix.arch}}.zip
+          name: WindowsTerminal-${{ inputs.version }}-${{ matrix.arch }}
+          path: C:\workspace\WindowsTerminal-${{ inputs.version }}-${{ matrix.arch }}.zip


### PR DESCRIPTION
Le secret DEVOLUTIONBOT_TOKEN va devenir read only, il ne sera donc plus possible de l'utiliser pour créer des releases. Le GITHUB_TOKEN par default devrait être suffisant.